### PR TITLE
Adding Postgres port env variable. Fix #7

### DIFF
--- a/.env-example.exs
+++ b/.env-example.exs
@@ -6,6 +6,7 @@ for {key, value} <- %{
   # Database credentials
   "NOVA_DB_USER" => "DB_USER",
   "NOVA_DB_PASSWORD" => "DB_PASSWORD",
+  "NOVA_DB_PORT" => "5432",
   # Secret key. To generate a new one, run: `mix phoenix.gen.secret`
   "NOVA_SECRET_KEY_BASE" => "somethingsecretenough"
 }, do: System.put_env(key, value)

--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ Don't know right now, _world domination™_? :-)
 
 ## Setup
 
-  1. Install dependencies with `mix deps.get`
-  2. Copy `.env-example.exs` to `.env.exs`, then edit it to set secret configs
+  1. Copy `.env-example.exs` to `.env.exs`, then edit it to set secret configs
+  2. Install dependencies with `mix deps.get`
   3. Create and migrate your database with `mix ecto.create && mix ecto.migrate`
   4. Run tests with `mix test`
+  5. Install npm dependencies with `npm install`
   5. Start Phoenix endpoint with `mix phoenix.server`
   6. Visit [`localhost:4000`](http://localhost:4000) from your browser

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -42,4 +42,5 @@ config :nova, Nova.Repo,
   username: System.get_env("NOVA_DB_USER"),
   password: System.get_env("NOVA_DB_PASSWORD"),
   database: "nova_dev",
+  port: System.get_env("NOVA_DB_PORT"),
   pool_size: 10

--- a/config/test.exs
+++ b/config/test.exs
@@ -22,4 +22,5 @@ config :nova, Nova.Repo,
   username: System.get_env("NOVA_DB_USER"),
   password: System.get_env("NOVA_DB_PASSWORD"),
   database: "nova_test",
+  port: System.get_env("NOVA_DB_PORT"),
   pool: Ecto.Adapters.SQL.Sandbox

--- a/setup_travis_ci.sh
+++ b/setup_travis_ci.sh
@@ -4,6 +4,7 @@ cat > .env.exs <<EOF
 for {key, value} <- %{
   "NOVA_DB_USER" => "postgres",
   "NOVA_DB_PASSWORD" => "",
+  "NOVA_DB_PORT" => "5432",
   "NOVA_SECRET_KEY_BASE" => "somethingsecretenough"
 }, do: System.put_env(key, value)
 EOF


### PR DESCRIPTION
Sometimes configuring non-standard ports is need it. This adds a env variable for doing this.
